### PR TITLE
Add default issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+
+<!-- A description of the issue goes here. Usually the more information, the better, but that doesn't mean walls of text. Conciseness, recordings, screenshots, links, etc. help you provide a lot of information without needing to write a lot. -->
+
+## Acceptance criteria
+<!-- List acceptance criteria here ... what should be true for this issue to be considered solved?
+
+This is not a task list. Acceptance criteria are written from the point of view of a user. For example, "User should be able to paginate through analysis executions 50 at a time". 
+
+If the user is an end-user rather than a developer, you can include what should be true about technical outputs like API contracts, database state, observability capabilities, etc.
+
+Keep in mind that the solution will do the *least* possible to satisfy these criteria, so if something is necessary, list it here.
+
+Acceptance criteria shouldn't cover the general engineering practices that are required to make a solution acceptable, like writing tests.
+-->
+
+- [ ] criteria1 <!-- Edit this -->
+- [ ] criteria2 <!-- Edit this -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Problem
+<!-- Why does this PR exist? What is the problem you're solving? Answer those questions here. -->
+
+## Solution
+<!-- 
+Explain _what_ you did to solve the problem here, and just as importantly, _why_ you did it that way. _How_ you solved the problem should be clear from the code. Our future selves will rely on this PR and the code to understand this change.
+
+Notably,
+1. If there's something in your code that may be confusing, unclear, or surprising, explain it. And consider whether those clarifications should be comments in your code instead.
+2. If additional steps are necessary after merging the PR, say what they are. 
+3. If you didn't put the code behind a feature flag, say why not, e.g. it can't technically be controlled by FF, etc.
+-->
+
+### Testing
+<!-- Explain how this code was tested here. If you wrote automated tests and no manual testing was conducted or is needed, you can leave this section out.
+-->

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # .github
+
+This repo contains default [community health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) for our GitHub repos. 


### PR DESCRIPTION
## Problem
We have lots of GitHub repos with different templates for issues and pull requests. As we add more repos, it's getting more difficult to establish and maintain conventions.

## Solution
Default templates have been added for issues and pull requests. These templates will be used in a repo that doesn't provide its own `ISSUE_TEMPLATE.md` and/or `PULL_REQUEST_TEMPLATE.md`.